### PR TITLE
Allow tab completion for solvers module

### DIFF
--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -251,6 +251,8 @@ spmatrix_repr = printing.spmatrix_repr_default
 from cvxopt.base import matrix, spmatrix, sparse, spdiag, sqrt, sin, cos, \
     exp, log 
 
+from cvxopt import solvers
+
 __all__ = [ 'blas', 'lapack', 'amd', 'umfpack', 'cholmod', 'solvers',
     'modeling', 'printing', 'info', 'matrix', 'spmatrix', 'sparse', 
     'spdiag', 'sqrt', 'sin', 'cos', 'exp', 'log', 'min', 'max', 'mul', 


### PR DESCRIPTION
[] import cvxopt

Currently

[] cvxopt.s # tab complete

doesn't list cvxopt.solvers

With this import, cvxopt.solvers is listed.
