### PR TITLE
Matrix_NewFromSequence: fix sequence object being leaked if empty

### DIFF
--- a/src/C/dense.c
+++ b/src/C/dense.c
@@ -316,7 +316,7 @@ matrix * Matrix_NewFromSequence(PyObject *x, int id)
     }
   }
 
-  if (!len) return Matrix_New(0, 1, (id < 0 ? INT : id));
+  if (!len) { Py_DECREF(seq); return Matrix_New(0, 1, (id < 0 ? INT : id)); }
 
   matrix *L = Matrix_New(len,1,id);
   if (!L) { Py_DECREF(seq); return (matrix *)PyErr_NoMemory(); }


### PR DESCRIPTION
On current master,

```
$ git describe
1.1.5-2-g140d5e2
```

cvxopt leaks empty sequences used to construct `matrix` objects:

``` python
$ python
Python 2.7.6 |Continuum Analytics, Inc.| (default, Nov 11 2013, 10:47:18) 
[GCC 4.1.2 20080704 (Red Hat 4.1.2-54)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import gc
>>> def count_lists():
...     gc.collect()
...     return len([o for o in gc.get_objects() if isinstance(o, list)])
... 
>>> from cvxopt.base import matrix
>>> m = matrix([]); count_lists()
117
>>> m = matrix([]); count_lists()
118
>>> m = matrix([]); count_lists()
119
```

Decreasing corresponding refcount fixes this for me.
