### PR TITLE
Changed "s is not positive" err msgs to "s is not strictly positive"

### DIFF
--- a/src/python/coneprog.py
+++ b/src/python/coneprog.py
@@ -712,7 +712,7 @@ def conelp(c, G, h, dims = None, A = None, b = None, primalstart = None,
     # ts = min{ t | s + t*e >= 0 }
     ts = misc.max_step(s, dims)
     if ts >= 0 and primalstart: 
-        raise ValueError("initial s is not positive")
+        raise ValueError("initial s is not strictly positive")
 
 
     if dualstart is None:
@@ -741,7 +741,7 @@ def conelp(c, G, h, dims = None, A = None, b = None, primalstart = None,
     # tz = min{ t | z + t*e >= 0 }
     tz = misc.max_step(z, dims)
     if tz >= 0 and dualstart: 
-        raise ValueError("initial z is not positive")
+        raise ValueError("initial z is not strictly positive")
 
     nrms = misc.snrm2(s, dims)
     nrmz = misc.snrm2(z, dims)
@@ -2132,7 +2132,7 @@ def coneqp(P, q, G = None, h = None, dims = None, A = None, b = None,
             blas.copy(initvals['s'], s)
             # ts = min{ t | s + t*e >= 0 }
             if misc.max_step(s, dims) >= 0:
-                raise ValueError("initial s is not positive")
+                raise ValueError("initial s is not strictly positive")
         else: 
             s[: dims['l']] = 1.0 
             ind = dims['l']
@@ -2152,7 +2152,7 @@ def coneqp(P, q, G = None, h = None, dims = None, A = None, b = None,
             blas.copy(initvals['z'], z)
             # tz = min{ t | z + t*e >= 0 }
             if misc.max_step(z, dims) >= 0:
-                raise ValueError("initial z is not positive")
+                raise ValueError("initial z is not strictly positive")
         else:
             z[: dims['l']] = 1.0 
             ind = dims['l']


### PR DESCRIPTION
Initial values for the dual variables 's' and 'z' in the coneprog.py solvers must be strictly positive, according to documentation.  If they are not, error messages say that 's' and 'z' are "not positive".  I changed these error messages to say "s is not strictly positive" to make this clearer.