### PR TITLE
Typo fix in spsolvers.rst

### DIFF
--- a/doc/source/spsolvers.rst
+++ b/doc/source/spsolvers.rst
@@ -70,7 +70,7 @@ As an example we consider the matrix
 
 
 >>> from cvxopt import spmatrix, amd 
->>> A = spmatrix([10,3,5,-2,5,2], [0,2,1,2,2,3], [0,0,1,1,2,3])
+>>> A = spmatrix([10,3,5,-2,5,2], [0,2,1,3,2,3], [0,0,1,1,2,3])
 >>> P = amd.order(A)
 >>> print(P)
 [ 1]


### PR DESCRIPTION
 Fixes x index for -2 entry in example matrix. Doesn't affect example's output though.
