### PR TITLE
Don't use non-standard void* arithmetic

### DIFF
--- a/src/C/base.c
+++ b/src/C/base.c
@@ -647,9 +647,9 @@ static PyObject* base_gemv(PyObject *self, PyObject *args, PyObject *kwrds)
   if (Matrix_Check(A)) {
     int ldA = MAX(1,X_NROWS(A));
     if (trans == 'N' && n == 0)
-      scal[id](&m, (bo ? &b : &Zero[id]), MAT_BUF(y)+oy*E_SIZE[id], &iy);
+      scal[id](&m, (bo ? &b : &Zero[id]), ((char*)MAT_BUF(y))+oy*E_SIZE[id], &iy);
     else if ((trans == 'T' || trans == 'C') && m == 0)
-      scal[id](&n, (bo ? &b : &Zero[id]), MAT_BUF(y)+oy*E_SIZE[id], &iy);
+      scal[id](&n, (bo ? &b : &Zero[id]), ((char*)MAT_BUF(y))+oy*E_SIZE[id], &iy);
     else
 #if PY_MAJOR_VERSION >= 3
       gemv[id](&trans_, &m, &n, (ao ? &a : &One[id]),
@@ -658,9 +658,9 @@ static PyObject* base_gemv(PyObject *self, PyObject *args, PyObject *kwrds)
           MAT_BUF(y) + oy*E_SIZE[id], &iy);
 #else
       gemv[id](&trans, &m, &n, (ao ? &a : &One[id]),
-          MAT_BUF(A) + oA*E_SIZE[id], &ldA,
-          MAT_BUF(x) + ox*E_SIZE[id], &ix, (bo ? &b : &Zero[id]),
-          MAT_BUF(y) + oy*E_SIZE[id], &iy);
+          ((char*)MAT_BUF(A)) + oA*E_SIZE[id], &ldA,
+          ((char*)MAT_BUF(x)) + ox*E_SIZE[id], &ix, (bo ? &b : &Zero[id]),
+          ((char*)MAT_BUF(y)) + oy*E_SIZE[id], &iy);
 #endif
   } else {
 #if PY_MAJOR_VERSION >= 3
@@ -670,8 +670,8 @@ static PyObject* base_gemv(PyObject *self, PyObject *args, PyObject *kwrds)
       return PyErr_NoMemory();
 #else
     if (sp_gemv[id](trans, m, n, (ao ? a : One[id]), ((spmatrix *)A)->obj,
-        oA, MAT_BUF(x) + ox*E_SIZE[id], ix, (bo ? b : Zero[id]),
-        MAT_BUF(y) + oy*E_SIZE[id], iy))
+        oA, ((char*)MAT_BUF(x)) + ox*E_SIZE[id], ix, (bo ? b : Zero[id]),
+        ((char*)MAT_BUF(y)) + oy*E_SIZE[id], iy))
       return PyErr_NoMemory();
 #endif
   }
@@ -894,8 +894,8 @@ static PyObject* base_symv(PyObject *self, PyObject *args, PyObject *kwrds)
         &ix, (bo ? &b : &Zero[id]), MAT_BUF(y) + oy*E_SIZE[id], &iy);
 #else
     symv[id](&uplo, &n, (ao ? &a : &One[id]),
-        MAT_BUF(A) + oA*E_SIZE[id], &ldA, MAT_BUF(x) + ox*E_SIZE[id],
-        &ix, (bo ? &b : &Zero[id]), MAT_BUF(y) + oy*E_SIZE[id], &iy);
+        ((char*)MAT_BUF(A)) + oA*E_SIZE[id], &ldA, ((char*)MAT_BUF(x)) + ox*E_SIZE[id],
+        &ix, (bo ? &b : &Zero[id]), ((char*)MAT_BUF(y)) + oy*E_SIZE[id], &iy);
 #endif
   }
   else {
@@ -906,8 +906,8 @@ static PyObject* base_symv(PyObject *self, PyObject *args, PyObject *kwrds)
         (bo ? b : Zero[id]), MAT_BUF(y) + oy*E_SIZE[id], iy))
 #else
     if (sp_symv[id](uplo, n, (ao ? a : One[id]), ((spmatrix *)A)->obj,
-        oA, MAT_BUF(x) + ox*E_SIZE[id], ix,
-        (bo ? b : Zero[id]), MAT_BUF(y) + oy*E_SIZE[id], iy))
+        oA, ((char*)MAT_BUF(x)) + ox*E_SIZE[id], ix,
+        (bo ? b : Zero[id]), ((char*)MAT_BUF(y)) + oy*E_SIZE[id], iy))
 #endif
       return PyErr_NoMemory();
   }

--- a/src/C/cholmod.c
+++ b/src/C/cholmod.c
@@ -528,7 +528,7 @@ static PyObject* solve(PyObject *self, PyObject *args, PyObject *kwrds)
 
     void *b_old = b->x;
     for (i=0; i<nrhs; i++){
-        b->x = MAT_BUF(B) + (i*ldB + oB)*E_SIZE[MAT_ID(B)];
+        b->x = (char*)MAT_BUF(B) + (i*ldB + oB)*E_SIZE[MAT_ID(B)];
         x = CHOL(solve) (sysvalues[sys], L, b, &Common);
         if (Common.status != CHOLMOD_OK){
             PyErr_SetString(PyExc_ValueError, "solve step failed");
@@ -785,7 +785,7 @@ static PyObject* linsolve(PyObject *self, PyObject *args,
     }
     b_old = b->x;
     for (i=0; i<nrhs; i++) {
-        b->x = MAT_BUF(B) + (i*ldB + oB)*E_SIZE[MAT_ID(B)];
+        b->x = (char*)MAT_BUF(B) + (i*ldB + oB)*E_SIZE[MAT_ID(B)];
         x = CHOL(solve) (CHOLMOD_A, L, b, &Common);
         if (Common.status != CHOLMOD_OK){
             PyErr_SetString(PyExc_ValueError, "solve step failed");

--- a/src/C/dense.c
+++ b/src/C/dense.c
@@ -101,7 +101,7 @@ static int convert_mtx(matrix *src, void *dest, int id)
 
   int_t i;
   for (i=0; i<MAT_LGT(src); i++)
-    if (convert_num[id](dest + i*E_SIZE[id], src, 0,i)) return -1;
+    if (convert_num[id]((char*)dest + i*E_SIZE[id], src, 0,i)) return -1;
 
   return 0;
 }
@@ -115,7 +115,7 @@ void * convert_mtx_alloc(matrix *src, int id)
 
   int_t i;
   for (i=0; i<MAT_LGT(src); i++)
-    if (convert_num[id](ptr + i*E_SIZE[id], src, 0,i))
+    if (convert_num[id]((char*)ptr + i*E_SIZE[id], src, 0,i))
       { free(ptr); return NULL; }
 
   return ptr;
@@ -231,21 +231,21 @@ matrix *Matrix_NewFromPyBuffer(PyObject *obj, int id, int *ndim)
      case INT :
        if (int_to_int_t)
 	 MAT_BUFI(a)[cnt] =
-	   *(int *)(view->buf+i*view->strides[0]+j*view->strides[1]);
+	   *(int *)((char*)view->buf+i*view->strides[0]+j*view->strides[1]);
        else
 	 MAT_BUFI(a)[cnt] =
-	   *(int_t *)(view->buf+i*view->strides[0]+j*view->strides[1]);
+	   *(int_t *)((char*)view->buf+i*view->strides[0]+j*view->strides[1]);
        break;
      case DOUBLE:
        switch (src_id) {
        case INT:
 	 if (int_to_int_t)
-	   n.d = *(int *)(view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.d = *(int *)((char*)view->buf + i*view->strides[0]+j*view->strides[1]);
 	 else
-	   n.d = *(int_t *)(view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.d = *(int_t *)((char*)view->buf + i*view->strides[0]+j*view->strides[1]);
 	 break;
        case DOUBLE:
-	 n.d = *(double *)(view->buf + i*view->strides[0]+j*view->strides[1]);
+	 n.d = *(double *)((char*)view->buf + i*view->strides[0]+j*view->strides[1]);
 	 break;
        }
        MAT_BUFD(a)[cnt] = n.d;
@@ -254,15 +254,15 @@ matrix *Matrix_NewFromPyBuffer(PyObject *obj, int id, int *ndim)
        switch (src_id) {
        case INT:
 	 if (int_to_int_t)
-	   n.z = *(int *)(view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.z = *(int *)((char*)view->buf + i*view->strides[0]+j*view->strides[1]);
 	 else
-	   n.z = *(int_t *)(view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.z = *(int_t *)((char*)view->buf + i*view->strides[0]+j*view->strides[1]);
     	 break;
        case DOUBLE:
-	 n.z = *(double *)(view->buf+i*view->strides[0]+j*view->strides[1]);
+	 n.z = *(double *)((char*)view->buf+i*view->strides[0]+j*view->strides[1]);
 	 break;
        case COMPLEX:
-	 n.z = *(double complex *)(view->buf+i*view->strides[0]+j*view->strides[1]);
+	 n.z = *(double complex *)((char*)view->buf+i*view->strides[0]+j*view->strides[1]);
 	 break;
        }
        MAT_BUFZ(a)[cnt] = n.z;
@@ -436,18 +436,18 @@ matrix * dense_concat(PyObject *L, int id_arg)
 
         if (Matrix_Check(Lij)) {
           for (ik=0; ik<blk_nrows; ik++)
-            convert_num[id](MAT_BUF(A) + (mk+ik+(nk+jk)*m)*E_SIZE[id],
+            convert_num[id]((char*)MAT_BUF(A) + (mk+ik+(nk+jk)*m)*E_SIZE[id],
                 Lij, 0, ik + jk*blk_nrows);
 
         } else if (SpMatrix_Check(Lij)) {
           for (ik=SP_COL(Lij)[jk]; ik<SP_COL(Lij)[jk+1]; ik++)
-            convert_array(MAT_BUF(A) + ((nk+jk)*m+mk+SP_ROW(Lij)[ik])*
-                E_SIZE[id], SP_VAL(Lij) + ik*E_SIZE[SP_ID(Lij)],
+            convert_array((char*)MAT_BUF(A) + ((nk+jk)*m+mk+SP_ROW(Lij)[ik])*
+                E_SIZE[id], (char*)SP_VAL(Lij) + ik*E_SIZE[SP_ID(Lij)],
                 id, SP_ID(Lij), 1);
 
         } else {
 
-          convert_num[id](MAT_BUF(A) + (mk+(nk+jk)*m)*E_SIZE[id],
+          convert_num[id]((char*)MAT_BUF(A) + (mk+(nk+jk)*m)*E_SIZE[id],
               Lij, 1, 0);
         }
       }

--- a/src/C/sparse.c
+++ b/src/C/sparse.c
@@ -240,7 +240,7 @@ spmatrix *SpMatrix_NewFromMatrix(matrix *src, int id)
   for (j=0; j<MAT_NCOLS(src); j++) {
     for (i=0; i<MAT_NROWS(src); i++) {
 
-      number *a = MAT_BUF(src) + (i+j*MAT_NROWS(src))*E_SIZE[MAT_ID(src)];
+      number *a = (number*)(((char*)MAT_BUF(src)) + (i+j*MAT_NROWS(src))*E_SIZE[MAT_ID(src)]);
       if (((MAT_ID(src) == INT) && (a->i != Zero[INT].i)) ||
           ((MAT_ID(src) == DOUBLE) && (a->d != Zero[DOUBLE].d)) ||
           ((MAT_ID(src) == COMPLEX) && (a->z != Zero[COMPLEX].z)))
@@ -309,8 +309,8 @@ spmatrix * sparse_concat(PyObject *L, int id_arg)
         for (jk=0; jk<MAT_NCOLS(Lij); jk++) {
           for (ik=0; ik<MAT_NROWS(Lij); ik++) {
 
-            number *a = MAT_BUF(Lij) +
-                (ik+jk*MAT_NROWS(Lij))*E_SIZE[MAT_ID(Lij)];
+            number *a = (number*)((char*)MAT_BUF(Lij) +
+                (ik+jk*MAT_NROWS(Lij))*E_SIZE[MAT_ID(Lij)]);
 
             if (((MAT_ID(Lij) == INT) && (a->i != Zero[INT].i)) ||
                 ((MAT_ID(Lij) == DOUBLE) && (a->d != Zero[DOUBLE].d)) ||
@@ -3236,7 +3236,7 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
               if (itype == 'n')
                 write_num[id](val_merge, tot_cnt++, &val, 0);
               else
-                convert_num[id](val_merge + E_SIZE[id]*tot_cnt++,
+                convert_num[id]((char*)val_merge + E_SIZE[id]*tot_cnt++,
                     value, 0, ilist[rhs_cnt].value);
 
               col_merge[j+1]++;
@@ -3253,7 +3253,7 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
               if (itype == 'n')
                 write_num[id](val_merge, tot_cnt++, &val, 0);
               else
-                convert_num[id](val_merge + E_SIZE[id]*tot_cnt++,
+                convert_num[id]((char*)val_merge + E_SIZE[id]*tot_cnt++,
                     value, 0, ilist[rhs_cnt].value);
               col_merge[j+1]++;
             }
@@ -3275,7 +3275,7 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
             if (itype == 'n')
               write_num[id](val_merge, tot_cnt++, &val, 0);
             else
-              convert_num[id](val_merge + E_SIZE[id]*tot_cnt++,
+              convert_num[id]((char*)val_merge + E_SIZE[id]*tot_cnt++,
                   value, 0, ilist[rhs_cnt].value);
             col_merge[j+1]++;
           }
@@ -3332,8 +3332,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
                 (rhs_cnt==0 || (rhs_cnt>0 && ilist[rhs_cnt].key !=
                     ilist[rhs_cnt-1].key))) {
               row_merge[tot_cnt] = rhs_i;
-              convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-                  SP_VAL(value) + E_SIZE[val_id]*ilist[rhs_cnt].value,
+              convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+                  (char*)SP_VAL(value) + E_SIZE[val_id]*ilist[rhs_cnt].value,
                   id, val_id, 1);
               col_merge[j+1]++;
             }
@@ -3348,8 +3348,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
                 (rhs_cnt>0 && ilist[rhs_cnt].key !=
                     ilist[rhs_cnt-1].key))) {
               row_merge[tot_cnt] = rhs_i;
-              convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-                  SP_VAL(value) + E_SIZE[val_id]*ilist[rhs_cnt].value,
+              convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+                  (char*)SP_VAL(value) + E_SIZE[val_id]*ilist[rhs_cnt].value,
                   id, val_id, 1);
               col_merge[j+1]++;
             }
@@ -3360,8 +3360,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
           }
           else {
             row_merge[tot_cnt] = SP_ROW(self)[i];
-            convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-                SP_VAL(self) + E_SIZE[id]*i, id, id, 1);
+            convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+                (char*)SP_VAL(self) + E_SIZE[id]*i, id, id, 1);
             col_merge[j+1]++;
           }
         }
@@ -3369,8 +3369,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
           if (ilist[rhs_cnt].value >= 0 && (rhs_cnt==0 || (rhs_cnt>0 &&
               ilist[rhs_cnt].key != ilist[rhs_cnt-1].key))) {
             row_merge[tot_cnt] = rhs_i;
-            convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-                SP_VAL(value) + E_SIZE[val_id]*ilist[rhs_cnt].value,
+            convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+                (char*)SP_VAL(value) + E_SIZE[val_id]*ilist[rhs_cnt].value,
                 id, val_id, 1);
             col_merge[j+1]++;
           }
@@ -3508,7 +3508,7 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
             if (itype == 'n')
               write_num[id](val_merge, tot_cnt++, &val, 0);
             else
-              convert_num[id](val_merge + E_SIZE[id]*tot_cnt++,
+              convert_num[id]((char*)val_merge + E_SIZE[id]*tot_cnt++,
                   value, 0, Is[rhs_cnti].value + lgtI*Js[rhs_cntj].value);
             col_merge[j+1]++;
           }
@@ -3524,7 +3524,7 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
             if (itype == 'n')
               write_num[id](val_merge, tot_cnt++, &val, 0);
             else
-              convert_num[id](val_merge + E_SIZE[id]*tot_cnt++,
+              convert_num[id]((char*)val_merge + E_SIZE[id]*tot_cnt++,
                   value, 0, Is[rhs_cnti].value + lgtI*Js[rhs_cntj].value);
 
             col_merge[j+1]++;
@@ -3534,8 +3534,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
         }
         else {
           row_merge[tot_cnt] = SP_ROW(self)[i];
-          convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-              SP_VAL(self) + E_SIZE[id]*i, id, id, 1);
+          convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+              (char*)SP_VAL(self) + E_SIZE[id]*i, id, id, 1);
           col_merge[j+1]++;
         }
       }
@@ -3548,7 +3548,7 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
           if (itype == 'n')
             write_num[id](val_merge, tot_cnt++, &val, 0);
           else
-            convert_num[id](val_merge + E_SIZE[id]*tot_cnt++,
+            convert_num[id]((char*)val_merge + E_SIZE[id]*tot_cnt++,
                 value, 0, Is[rhs_cnti].value + lgtI*Js[rhs_cntj].value);
 
           col_merge[j+1]++;
@@ -3621,8 +3621,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
               (rhs_cnti>0 && Is[rhs_cnti].key != Is[rhs_cnti-1].key))) {
             row_merge[tot_cnt] = rhs_i;
 
-            convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-                SP_VAL(value) + E_SIZE[val_id]*
+            convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+                (char*)SP_VAL(value) + E_SIZE[val_id]*
                 (Is[rhs_cnti].value+rhs_offs_rptr), id, val_id, 1);
 
             col_merge[j+1]++;
@@ -3635,8 +3635,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
               (rhs_cnti>0 && Is[rhs_cnti].key != Is[rhs_cnti-1].key))) {
             row_merge[tot_cnt] = rhs_i;
 
-            convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-                SP_VAL(value) + E_SIZE[val_id]*
+            convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+                (char*)SP_VAL(value) + E_SIZE[val_id]*
                 (Is[rhs_cnti].value+rhs_offs_rptr), id, val_id, 1);
 
             col_merge[j+1]++;
@@ -3646,8 +3646,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
         }
         else {
           row_merge[tot_cnt] = SP_ROW(self)[i];
-          convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-              SP_VAL(self) + E_SIZE[id]*i, id, id, 1);
+          convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+              (char*)SP_VAL(self) + E_SIZE[id]*i, id, id, 1);
           col_merge[j+1]++;
         }
       }
@@ -3657,8 +3657,8 @@ spmatrix_ass_subscr(spmatrix* self, PyObject* args, PyObject* value)
 
           row_merge[tot_cnt] = rhs_i;
 
-          convert_array(val_merge + E_SIZE[id]*tot_cnt++,
-              SP_VAL(value) + E_SIZE[val_id]*
+          convert_array((char*)val_merge + E_SIZE[id]*tot_cnt++,
+              (char*)SP_VAL(value) + E_SIZE[val_id]*
               (Is[rhs_cnti].value+rhs_offs_rptr), id, val_id, 1);
 
           col_merge[j+1]++;

--- a/src/C/umfpack.c
+++ b/src/C/umfpack.c
@@ -225,7 +225,7 @@ static PyObject* linsolve(PyObject *self, PyObject *args,
                 (double *)(MAT_BUFZ(B) + k*ldB + oB), NULL, numeric,
                 NULL, info);
         if (info[UMFPACK_STATUS] == UMFPACK_OK)
-            memcpy(B->buffer + (k*ldB + oB)*E_SIZE[SP_ID(A)], x,
+            memcpy((char*)B->buffer + (k*ldB + oB)*E_SIZE[SP_ID(A)], x,
                 n*E_SIZE[SP_ID(A)]);
         else
 	    break;
@@ -548,7 +548,7 @@ static PyObject* solve(PyObject *self, PyObject *args, PyObject *kwrds)
                 (void *) PyCObject_AsVoidPtr(F), NULL, info);
 #endif
         if (info[UMFPACK_STATUS] == UMFPACK_OK)
-            memcpy(B->buffer + (k*ldB + oB)*E_SIZE[SP_ID(A)], x,
+            memcpy((char*)B->buffer + (k*ldB + oB)*E_SIZE[SP_ID(A)], x,
                 n*E_SIZE[SP_ID(A)]);
         else
 	    break;


### PR DESCRIPTION
This PR removes all the known uses of `void*` arithmetic, which is not valid C but is a gcc extension.

Note: this is the first step toward making cvxopt better supported on Windows. We are providing cvxopt on windows (including 64 bits) in our Canopy product at Enthought. The GPL requires us to put the changed sources somewhere, and I thought it would be better for cvxopt to have those in the form of PRs instead of one big patch.