### PR TITLE
BACKPORT: Fixed linking order when linking against external SuiteSparse library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ GSL_LIB_DIR = '/usr/lib'
 GSL_INC_DIR = '/usr/include/gsl'
 
 # Set to 1 if you are installing the fftw module.
-BUILD_FFTW = 0 
+BUILD_FFTW = 0
 
 # Directory containing libfftw3 (used only when BUILD_FFTW = 1).
 FFTW_LIB_DIR = '/usr/lib'
@@ -37,7 +37,7 @@ FFTW_LIB_DIR = '/usr/lib'
 FFTW_INC_DIR = '/usr/include'
 
 # Set to 1 if you are installing the glpk module.
-BUILD_GLPK = 0 
+BUILD_GLPK = 0
 
 # Directory containing libglpk (used only when BUILD_GLPK = 1).
 GLPK_LIB_DIR = '/usr/lib'
@@ -50,7 +50,7 @@ BUILD_DSDP = 0
 
 # Directory containing libdsdp (used only when BUILD_DSDP = 1).
 DSDP_LIB_DIR = '/usr/lib'
- 
+
 # Directory containing dsdp5.h (used only when BUILD_DSDP = 1).
 DSDP_INC_DIR = '/usr/include/dsdp'
 
@@ -86,8 +86,8 @@ BUILD_DSDP = int(os.environ.get("CVXOPT_BUILD_DSDP",BUILD_DSDP))
 DSDP_LIB_DIR = os.environ.get("CVXOPT_DSDP_LIB_DIR",DSDP_LIB_DIR)
 DSDP_INC_DIR = os.environ.get("CVXOPT_DSDP_INC_DIR",DSDP_INC_DIR)
 SUITESPARSE_EXT_LIB = os.environ.get("CVXOPT_SUITESPARSE_EXT_LIB",SUITESPARSE_EXT_LIB)
-SUITESPARSE_LIB_DIR = os.environ.get("CVXOPT_AMD_EXT_LIB",SUITESPARSE_LIB_DIR)
-SUITESPARSE_INC_DIR = os.environ.get("CVXOPT_AMD_EXT_LIB",SUITESPARSE_INC_DIR)
+SUITESPARSE_LIB_DIR = os.environ.get("CVXOPT_SUITESPARSE_LIB_DIR",SUITESPARSE_LIB_DIR)
+SUITESPARSE_INC_DIR = os.environ.get("CVXOPT_SUITESPARSE_INC_DIR",SUITESPARSE_INC_DIR)
 
 extmods = []
 
@@ -134,7 +134,7 @@ base = Extension('base', libraries = ['m'] + LAPACK_LIB + BLAS_LIB,
     library_dirs = [ BLAS_LIB_DIR ],
     define_macros = MACROS,
     extra_link_args = BLAS_EXTRA_LINK_ARGS,
-    sources = ['src/C/base.c','src/C/dense.c','src/C/sparse.c']) 
+    sources = ['src/C/base.c','src/C/dense.c','src/C/sparse.c'])
 
 blas = Extension('blas', libraries = BLAS_LIB,
     library_dirs = [ BLAS_LIB_DIR ],
@@ -155,10 +155,10 @@ if SUITESPARSE_EXT_LIB:
         library_dirs = [SUITESPARSE_LIB_DIR],
         sources = ['src/C/umfpack.c'])
 else:
-    umfpack = Extension('umfpack', 
+    umfpack = Extension('umfpack',
         include_dirs = [ 'src/C/SuiteSparse/UMFPACK/Include',
-            'src/C/SuiteSparse/AMD/Include', 
-            'src/C/SuiteSparse/AMD/Source', 
+            'src/C/SuiteSparse/AMD/Include',
+            'src/C/SuiteSparse/AMD/Source',
             'src/C/SuiteSparse/SuiteSparse_config' ],
         library_dirs = [ BLAS_LIB_DIR ],
         define_macros = MACROS + [('NTIMER', '1'), ('NCHOLMOD', '1')],
@@ -171,7 +171,7 @@ else:
             ['src/C/SuiteSparse/SuiteSparse_config/SuiteSparse_config.c'] +
             glob('src/C/SuiteSparse_cvxopt_extra/umfpack/*'))
 
-# Build for int or long? 
+# Build for int or long?
 import sys
 if sys.maxsize > 2**31: MACROS += [('DLONG',None)]
 
@@ -185,14 +185,14 @@ else:
     cholmod = Extension('cholmod',
         library_dirs = [ BLAS_LIB_DIR ],
         libraries = LAPACK_LIB + BLAS_LIB,
-        include_dirs = [ 'src/C/SuiteSparse/CHOLMOD/Include', 
-            'src/C/SuiteSparse/COLAMD', 
-            'src/C/SuiteSparse/AMD/Include', 
+        include_dirs = [ 'src/C/SuiteSparse/CHOLMOD/Include',
+            'src/C/SuiteSparse/COLAMD',
+            'src/C/SuiteSparse/AMD/Include',
             'src/C/SuiteSparse/COLAMD/Include',
             'src/C/SuiteSparse/SuiteSparse_config' ],
         define_macros = MACROS + [('NPARTITION', '1'), ('NTIMER', '1')],
         extra_link_args = BLAS_EXTRA_LINK_ARGS,
-        sources = [ 'src/C/cholmod.c' ] + 
+        sources = [ 'src/C/cholmod.c' ] +
             ['src/C/SuiteSparse/AMD/Source/' + s for s in ['amd_global.c',
                 'amd_postorder.c', 'amd_post_tree.c', 'amd_2.c']] +
             ['src/C/SuiteSparse/COLAMD/Source/' + s for s in ['colamd.c',
@@ -210,8 +210,8 @@ if SUITESPARSE_EXT_LIB:
         library_dirs = [SUITESPARSE_LIB_DIR],
         sources = ['src/C/amd.c'])
 else:
-    amd = Extension('amd', 
-        include_dirs = [ 'src/C/SuiteSparse/AMD/Include', 
+    amd = Extension('amd',
+        include_dirs = [ 'src/C/SuiteSparse/AMD/Include',
             'src/C/SuiteSparse/SuiteSparse_config' ],
         define_macros = MACROS,
         sources = [ 'src/C/amd.c', 'src/C/SuiteSparse/SuiteSparse_config/SuiteSparse_config.c'] +
@@ -224,20 +224,20 @@ misc_solvers = Extension('misc_solvers',
     extra_link_args = BLAS_EXTRA_LINK_ARGS,
     sources = ['src/C/misc_solvers.c'] )
 
-extmods += [base, blas, lapack, umfpack, cholmod, amd, misc_solvers] 
+extmods += [base, blas, lapack, umfpack, cholmod, amd, misc_solvers]
 
-setup (name = 'cvxopt', 
+setup (name = 'cvxopt',
     description = 'Convex optimization package',
-    version = '1.1.8', 
+    version = '1.1.8',
     long_description = '''
-CVXOPT is a free software package for convex optimization based on the 
-Python programming language. It can be used with the interactive Python 
-interpreter, on the command line by executing Python scripts, or 
-integrated in other software via Python extension modules. Its main 
-purpose is to make the development of software for convex optimization 
-applications straightforward by building on Python's extensive standard 
-library and on the strengths of Python as a high-level programming 
-language.''', 
+CVXOPT is a free software package for convex optimization based on the
+Python programming language. It can be used with the interactive Python
+interpreter, on the command line by executing Python scripts, or
+integrated in other software via Python extension modules. Its main
+purpose is to make the development of software for convex optimization
+applications straightforward by building on Python's extensive standard
+library and on the strengths of Python as a high-level programming
+language.''',
     author = 'M. Andersen, J. Dahl, and L. Vandenberghe',
     author_email = 'martin.skovgaard.andersen@gmail.com, dahl.joachim@gmail.com, vandenbe@ee.ucla.edu',
     url = 'http://cvxopt.org',

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ except ImportError:
     from distutils.core import setup, Extension
 from glob import glob
 import os
+import sys
 
 # Modifiy this if BLAS and LAPACK libraries are not in /usr/lib.
 BLAS_LIB_DIR = '/usr/lib'
@@ -89,6 +90,8 @@ SUITESPARSE_EXT_LIB = os.environ.get("CVXOPT_SUITESPARSE_EXT_LIB",SUITESPARSE_EX
 SUITESPARSE_LIB_DIR = os.environ.get("CVXOPT_SUITESPARSE_LIB_DIR",SUITESPARSE_LIB_DIR)
 SUITESPARSE_INC_DIR = os.environ.get("CVXOPT_SUITESPARSE_INC_DIR",SUITESPARSE_INC_DIR)
 
+RT_LIB = ["rt"] if sys.platform.startswith("linux") else []
+
 extmods = []
 
 # Macros
@@ -150,7 +153,7 @@ lapack = Extension('lapack', libraries = LAPACK_LIB + BLAS_LIB,
 
 if SUITESPARSE_EXT_LIB:
     umfpack = Extension('umfpack',
-        libraries = ['amd','colamd','suitesparseconfig','cholmod','umfpack'],
+        libraries = ['umfpack','cholmod','amd','colamd','suitesparseconfig'] + LAPACK_LIB + BLAS_LIB + RT_LIB,
         include_dirs = [SUITESPARSE_INC_DIR],
         library_dirs = [SUITESPARSE_LIB_DIR],
         sources = ['src/C/umfpack.c'])
@@ -172,12 +175,11 @@ else:
             glob('src/C/SuiteSparse_cvxopt_extra/umfpack/*'))
 
 # Build for int or long?
-import sys
 if sys.maxsize > 2**31: MACROS += [('DLONG',None)]
 
 if SUITESPARSE_EXT_LIB:
     cholmod = Extension('cholmod',
-        libraries = ['amd','colamd','suitesparseconfig','cholmod'],
+        libraries = ['cholmod','colamd','amd','suitesparseconfig'] + LAPACK_LIB + BLAS_LIB + RT_LIB,
         include_dirs = [SUITESPARSE_INC_DIR],
         library_dirs = [SUITESPARSE_LIB_DIR],
         sources = [ 'src/C/cholmod.c' ])
@@ -205,7 +207,7 @@ else:
 
 if SUITESPARSE_EXT_LIB:
     amd = Extension('amd',
-        libraries = ['amd','suitesparseconfig'],
+        libraries = ['amd','suitesparseconfig'] + RT_LIB,
         include_dirs = [SUITESPARSE_INC_DIR],
         library_dirs = [SUITESPARSE_LIB_DIR],
         sources = ['src/C/amd.c'])


### PR DESCRIPTION
Backports commits ( https://github.com/cvxopt/cvxopt/commit/4e89755cb6aaf6493a49a3ad99dd5d5e007e1a5a ) and ( https://github.com/cvxopt/cvxopt/commit/007c1a0ea9df9a54e9f99cacbde56a6047518375 ) so that they can be easily applied on `master`.

This PR is not intended for merging, but is merely created to demonstrate how I backported this commit to generate the patch used in the conda-forge build recipe ( https://github.com/conda-forge/cvxopt-feedstock/pull/4 ). 