### PR TITLE
Package license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Adds the license file to `MANIFEST.in` so as to ensure it is included in `sdist`s and other packages.