### PR TITLE
Mosek LP interface

### DIFF
--- a/src/python/msk.py
+++ b/src/python/msk.py
@@ -119,7 +119,7 @@ def lp(c, G, h, A=None, b=None, taskfile=None):
  
     bkc = m*[ mosek.boundkey.up ] + p*[ mosek.boundkey.fx ]
     blc = m*[ -inf ] + [ bi for bi in b ]
-    buc = matrix([h, b])
+    buc = list(h) + list(b)
 
     bkx = n*[mosek.boundkey.fr] 
     blx = n*[ -inf ] 
@@ -168,7 +168,7 @@ def lp(c, G, h, A=None, b=None, taskfile=None):
 
     solsta = task.getsolsta(mosek.soltype.bas)
 
-    x, z = n*[ 0.0 ], n*[ 0.0 ]
+    x, z = n*[ 0.0 ], m*[ 0.0 ]
     task.getsolutionslice(mosek.soltype.bas, mosek.solitem.xx, 0, n, x) 
     task.getsolutionslice(mosek.soltype.bas, mosek.solitem.suc, 0, m, z) 
     x, z = matrix(x), matrix(z)
@@ -930,7 +930,7 @@ def ilp(c, G, h, A=None, b=None, I=None, taskfile=None):
 
     bkc = m*[ mosek.boundkey.up ] + p*[ mosek.boundkey.fx ]
     blc = m*[ -inf ] + [ bi for bi in b ]
-    buc = matrix([h, b])
+    buc = list(h) + list(b)
 
     bkx = n*[mosek.boundkey.fr] 
     blx = n*[ -inf ] 


### PR DESCRIPTION
A user reported that the lp solver does not work because of a shape broadcast error. This is a proposed fix together with one other small typo. Here is the original error

```
  File "fail.py", line 108, in <module>
    opt = find_x_opt(N, xi, e)
  File "fail.py", line 93, in find_x_opt
    sol = solvers.lp(c, G, h, A, b, solver='mosek')
  File "/home/aszek/.local/lib/python2.7/site-packages/cvxopt/coneprog.py", line 2883, in lp
    solsta, x, z, y  = msk.lp(c, G, h, A, b)
  File "/home/aszek/.local/lib/python2.7/site-packages/cvxopt/msk.py", line 158, in lp
    bux) 
  File "/home/aszek/.local/lib/python2.7/site-packages/mosek/__init__.py", line 142, in accept
    return fun(*[ t(a) for (t,a) in zip(argtlst,args) ])
  File "/home/aszek/.local/lib/python2.7/site-packages/mosek/__init__.py", line 37, in sync
    return f(self,*args,**kwds)
  File "/home/aszek/.local/lib/python2.7/site-packages/mosek/__init__.py", line 7778, in inputdata
    _buc_np_tmp[:] = buc_
ValueError: could not broadcast input array from shape (21,1) into shape (21)
```