### PR TITLE
Remove a print statement which is not controlled by any flag.

### DIFF
--- a/src/python/coneprog.py
+++ b/src/python/coneprog.py
@@ -3488,8 +3488,6 @@ def socp(c, Gl = None, hl = None, Gq = None, hq = None, A = None, b = None,
             pinfres, dinfres = None, None
             pslack, dslack = None, None
 
-        print(status)
-
         return {'status': status, 'x': x, 'sl': sl, 'sq': sq, 'y': y,
             'zl': zl, 'zq': zq, 'primal objective': pcost,
             'dual objective': dcost, 'gap': gap, 'relative gap': relgap,


### PR DESCRIPTION
This print statement is removed because:

1. It is not controlled by any flag. Maybe it was written for debug purpose.

2. More detailed could be printed by mosek. And the printed status is not a temporary variable, instead it is already returned as a value in the dict. Any print statement could be conducted with that dict.