### PR TITLE
Fix mixed boolean/integer operations.

### DIFF
--- a/src/C/base.c
+++ b/src/C/base.c
@@ -1252,13 +1252,13 @@ PyObject * matrix_elem_max(PyObject *self, PyObject *args, PyObject *kwrds)
     if (PyNumber_Check(A) || Matrix_Check(A))
       convert_num[id](&a, A, PyNumber_Check(A), 0);
     else
-      a.d = (SP_LGT(A) ? SP_VALD(A)[0] : 0.0);
+      a.d = ((SP_LGT(A) > 0) ? SP_VALD(A)[0] : 0.0);
   }
   if (b_is_number) {
     if (PyNumber_Check(B) || Matrix_Check(B))
       convert_num[id](&b, B, PyNumber_Check(B), 0);
     else
-      b.d = (SP_LGT(B) ? SP_VALD(B)[0] : 0.0);
+      b.d = ((SP_LGT(B) > 0) ? SP_VALD(B)[0] : 0.0);
   }
 
   if ((a_is_number && b_is_number) &&
@@ -1431,13 +1431,13 @@ PyObject * matrix_elem_min(PyObject *self, PyObject *args, PyObject *kwrds)
     if (PyNumber_Check(A) || Matrix_Check(A))
       convert_num[id](&a, A, PyNumber_Check(A), 0);
     else
-      a.d = (SP_LGT(A) ? SP_VALD(A)[0] : 0.0);
+      a.d = ((SP_LGT(A) > 0) ? SP_VALD(A)[0] : 0.0);
   }
   if (b_is_number) {
     if (PyNumber_Check(B) || Matrix_Check(B))
       convert_num[id](&b, B, PyNumber_Check(B), 0);
     else
-      b.d = (SP_LGT(B) ? SP_VALD(B)[0] : 0.0);
+      b.d = ((SP_LGT(B) > 0) ? SP_VALD(B)[0] : 0.0);
   }
 
   if ((a_is_number && b_is_number) &&

--- a/src/C/sparse.c
+++ b/src/C/sparse.c
@@ -4409,7 +4409,7 @@ static PyObject *
 spmatrix_div_generic(spmatrix *A, PyObject *B, int inplace)
 {
   if (!SpMatrix_Check(A) || !(PY_NUMBER(B) ||
-      (Matrix_Check(B) && MAT_LGT(B)) == 1))
+      (Matrix_Check(B) && MAT_LGT(B) == 1)))
     PY_ERR_TYPE("invalid operands for sparse division");
 
   int idA = get_id(A, 0);


### PR DESCRIPTION
This fixes the following warnings, seen with GCC 9.x:
```
In file included from src/C/base.c:25:
src/C/base.c: In function ‘matrix_elem_max’:
src/C/cvxopt.h:136:34: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]
  136 | #define SP_LGT(O)    (SP_NROWS(O)*SP_NCOLS(O))
      |                      ~~~~~~~~~~~~^~~~~~~~~~~~~
src/C/base.c:1255:14: note: in expansion of macro ‘SP_LGT’
 1255 |       a.d = (SP_LGT(A) ? SP_VALD(A)[0] : 0.0);
      |              ^~~~~~
```
And several more of the same form, then:
```
In file included from src/C/sparse.c:25:
src/C/sparse.c: In function ‘spmatrix_div_generic’:
src/C/cvxopt.h:131:35: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]
  131 | #define MAT_LGT(O)   (MAT_NROWS(O)*MAT_NCOLS(O))
      |                      ~~~~~~~~~~~~~^~~~~~~~~~~~~~
src/C/sparse.c:4412:27: note: in expansion of macro ‘MAT_LGT’
 4412 |       (Matrix_Check(B) && MAT_LGT(B)) == 1))
      |                           ^~~~~~~
```