### PR TITLE
Fix misuses of 'is' and 'is not'.

### DIFF
--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -133,7 +133,7 @@ def setseed(val = 0):
         gsl.setseed(val)
     except:
         from random import seed
-        if val is 0: val = None
+        if val == 0: val = None
         seed(val)
         
  

--- a/src/python/coneprog.py
+++ b/src/python/coneprog.py
@@ -4040,7 +4040,7 @@ def sdp(c, Gl = None, hl = None, Gs = None, hs = None, A = None, b = None,
             pslack = -misc.max_step(s, dims)
             dslack = -misc.max_step(z, dims)
 
-            if status is 'optimal' or dcost <= 0.0:
+            if status == 'optimal' or dcost <= 0.0:
                 pinfres = None
             else:
                 # rx = G'*z
@@ -4058,7 +4058,7 @@ def sdp(c, Gl = None, hl = None, Gs = None, hs = None, A = None, b = None,
                     ind += ms[k]
                 pinfres = blas.nrm2(rx) / resx0 / dcost
 
-            if status is 'optimal' or pcost >= 0.0:
+            if status == 'optimal' or pcost >= 0.0:
                 dinfres = None
             else:
                 # rz = G*x + s

--- a/src/python/misc.py
+++ b/src/python/misc.py
@@ -913,7 +913,7 @@ else:
     # 
     # where Yk = mat(yk) if diag is 'N' and Yk = diag(yk) if diag is 'D'.
 
-    if diag is 'N':
+    if diag == 'N':
         maxm = max([0] + dims['s'])
         A = matrix(0.0, (maxm, maxm))
 

--- a/src/python/msk.py
+++ b/src/python/msk.py
@@ -102,7 +102,7 @@ def lp(c, G, h, A=None, b=None, taskfile=None, **kwargs):
             raise TypeError("'G' must be a dense or sparse 'd' matrix "\
                 "with %d columns" %n)
         m = G.size[0]
-        if m is 0: raise ValueError("m cannot be 0")
+        if m == 0: raise ValueError("m cannot be 0")
 
         if type(h) is not matrix or h.typecode != 'd' or h.size != (m,1):
             raise TypeError("'h' must be a 'd' matrix of size (%d,1)" %m)
@@ -175,7 +175,7 @@ def lp(c, G, h, A=None, b=None, taskfile=None, **kwargs):
             task.getsolutionslice(mosek.soltype.bas, mosek.solitem.suc, 0, m, z)
             x, z = matrix(x), matrix(z)
 
-            if p is not 0:
+            if p != 0:
                 yu, yl = p*[0.0], p*[0.0]
                 task.getsolutionslice(mosek.soltype.bas, mosek.solitem.suc, m, m+p, yu)
                 task.getsolutionslice(mosek.soltype.bas, mosek.solitem.slc, m, m+p, yl)
@@ -311,7 +311,7 @@ def conelp(c, G, h, dims=None, taskfile=None, **kwargs):
 
         ml, mq, ms = dims['l'], dims['q'], [ k*k for k in dims['s'] ]
         cdim = ml + sum(mq) + sum(ms)
-        if cdim is 0: raise ValueError("ml+mq+ms cannot be 0")
+        if cdim == 0: raise ValueError("ml+mq+ms cannot be 0")
 
         # Data for kth 'q' constraint are found in rows indq[k]:indq[k+1] of G.
         indq = [ dims['l'] ]
@@ -747,7 +747,7 @@ def qp(P, q, G=None, h=None, A=None, b=None, taskfile=None, **kwargs):
         if type(b) is not matrix or b.typecode != 'd' or b.size != (p,1):
             raise TypeError("'b' must be a dense matrix of size (%d,1)" %p)
 
-        if m+p is 0: raise ValueError("m + p must be greater than 0")
+        if m+p == 0: raise ValueError("m + p must be greater than 0")
 
         c = list(q)
 
@@ -812,7 +812,7 @@ def qp(P, q, G=None, h=None, A=None, b=None, taskfile=None, **kwargs):
             task.getsolutionslice(mosek.soltype.itr, mosek.solitem.xx, 0, n, x)
             x = matrix(x)
 
-            if m is not 0:
+            if m != 0:
                 z = m*[0.0]
                 task.getsolutionslice(mosek.soltype.itr, mosek.solitem.suc, 0, m,
                     z)
@@ -820,7 +820,7 @@ def qp(P, q, G=None, h=None, A=None, b=None, taskfile=None, **kwargs):
             else:
                 z = matrix(0.0, (0,1))
 
-            if p is not 0:
+            if p != 0:
                 yu, yl = p*[0.0], p*[0.0]
                 task.getsolutionslice(mosek.soltype.itr, mosek.solitem.suc, m, m+p,
                     yu)
@@ -901,7 +901,7 @@ def ilp(c, G, h, A=None, b=None, I=None, taskfile=None, **kwargs):
             raise TypeError("'G' must be a dense or sparse 'd' matrix "\
                 "with %d columns" %n)
         m = G.size[0]
-        if m is 0: raise ValueError("m cannot be 0")
+        if m == 0: raise ValueError("m cannot be 0")
 
         if type(h) is not matrix or h.typecode != 'd' or h.size != (m,1):
             raise TypeError("'h' must be a 'd' matrix of size (%d,1)" %m)

--- a/src/python/printing.py
+++ b/src/python/printing.py
@@ -40,8 +40,8 @@ def matrix_str_default(X):
     if width < 0: width = maxsize
     if height < 0: height = maxsize
 
-    if width*height is 0: return ""
-    if len(X) is 0: return ""
+    if width*height == 0: return ""
+    if len(X) == 0: return ""
 
     rlist = range(0,min(m,height))
     clist = range(0,min(n,width))
@@ -98,7 +98,7 @@ def spmatrix_str_default(X):
     if width < 0: width = maxsize
     if height < 0: height = maxsize
 
-    if width*height is 0: return ""
+    if width*height == 0: return ""
  
     rlist = range(0,min(m,height))
     clist = range(0,min(n,width))


### PR DESCRIPTION
Python 3.8 issues warnings of this form:
```
/usr/lib64/python3.8/site-packages/cvxopt/__init__.py:136: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
This pull request eliminates all such warnings by converting `is literal` to `== literal` and `is not literal` to `!= literal`.