### PR TITLE
redo {spmatrix,matrix}iter_tp to use PyType_Ready

### DIFF
--- a/src/C/base.c
+++ b/src/C/base.c
@@ -30,12 +30,14 @@
 PyDoc_STRVAR(base__doc__,"Convex optimization package");
 
 extern PyTypeObject matrix_tp ;
+extern PyTypeObject matrixiter_tp ;
 matrix * Matrix_New(int, int, int) ;
 matrix * Matrix_NewFromMatrix(matrix *, int) ;
 matrix * Matrix_NewFromSequence(PyObject *, int) ;
 matrix * Matrix_NewFromPyBuffer(PyObject *, int, int *) ;
 
 extern PyTypeObject spmatrix_tp ;
+extern PyTypeObject spmatrixiter_tp ;
 spmatrix * SpMatrix_New(int_t, int_t, int_t, int ) ;
 spmatrix * SpMatrix_NewFromMatrix(matrix *, int) ;
 spmatrix * SpMatrix_NewFromSpMatrix(spmatrix *, int) ;
@@ -2006,7 +2008,7 @@ PyMODINIT_FUNC initbase(void)
   if (PyType_Ready(&matrix_tp) < 0)
     INITERROR;
 
-  if (PyType_Ready(&matrix_tp) < 0)
+  if (PyType_Ready(&matrixiter_tp) < 0)
     INITERROR;
 
   Py_INCREF(&matrix_tp);
@@ -2016,6 +2018,9 @@ PyMODINIT_FUNC initbase(void)
   spmatrix_tp.tp_alloc = PyType_GenericAlloc;
   spmatrix_tp.tp_free = PyObject_Del;
   if (PyType_Ready(&spmatrix_tp) < 0)
+    INITERROR;
+
+  if (PyType_Ready(&spmatrixiter_tp) < 0)
     INITERROR;
 
   Py_INCREF(&spmatrix_tp);

--- a/src/C/dense.c
+++ b/src/C/dense.c
@@ -2133,7 +2133,7 @@ typedef struct {
   matrix *mObj;
 } matrixiter;
 
-static PyTypeObject matrixiter_tp;
+PyTypeObject matrixiter_tp;
 
 #define MatrixIter_Check(O) PyObject_TypeCheck(O, &matrixiter_tp)
 
@@ -2149,9 +2149,6 @@ matrix_iter(matrix *obj)
 
   it = PyObject_GC_New(matrixiter, &matrixiter_tp);
   if (!it) return NULL;
-
-  matrixiter_tp.tp_iter = PyObject_SelfIter;
-  matrixiter_tp.tp_getattro = PyObject_GenericGetAttr;
 
   Py_INCREF(obj);
   it->index = 0;
@@ -2188,7 +2185,7 @@ matrixiter_next(matrixiter *it)
   return num2PyObject[it->mObj->id](it->mObj->buffer, it->index++);
 }
 
-static PyTypeObject matrixiter_tp = {
+PyTypeObject matrixiter_tp = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "matrixiter",                       /* tp_name */
     sizeof(matrixiter),                 /* tp_basicsize */
@@ -2205,7 +2202,7 @@ static PyTypeObject matrixiter_tp = {
     0,                                  /* tp_hash */
     0,                                  /* tp_call */
     0,                                  /* tp_str */
-    0,                                  /* tp_getattro */
+    PyObject_GenericGetAttr,            /* tp_getattro */
     0,                                  /* tp_setattro */
     0,	                                /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
@@ -2214,7 +2211,7 @@ static PyTypeObject matrixiter_tp = {
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
     0,                                  /* tp_weaklistoffset */
-    0,                                  /* tp_iter */
+    PyObject_SelfIter,                  /* tp_iter */
     (iternextfunc)matrixiter_next,      /* tp_iternext */
     0,                                  /* tp_methods */
 };

--- a/src/C/sparse.c
+++ b/src/C/sparse.c
@@ -4536,7 +4536,7 @@ typedef struct {
   spmatrix *mObj;   /* Set to NULL when iterator is exhausted */
 } spmatrixiter;
 
-static PyTypeObject spmatrixiter_tp;
+PyTypeObject spmatrixiter_tp;
 
 #define SpMatrixIter_Check(O) PyObject_TypeCheck(O, &spmatrixiter_tp)
 
@@ -4549,9 +4549,6 @@ spmatrix_iter(spmatrix *obj)
     PyErr_BadInternalCall();
     return NULL;
   }
-
-  spmatrixiter_tp.tp_iter = PyObject_SelfIter;
-  spmatrixiter_tp.tp_getattro = PyObject_GenericGetAttr;
 
   it = PyObject_GC_New(spmatrixiter, &spmatrixiter_tp);
   if (it == NULL)
@@ -4592,7 +4589,7 @@ spmatrixiter_next(spmatrixiter *it)
   return num2PyObject[SP_ID(it->mObj)](SP_VAL(it->mObj), it->index++);
 }
 
-static PyTypeObject spmatrixiter_tp = {
+PyTypeObject spmatrixiter_tp = {
 #if PY_MAJOR_VERSION >= 3
     PyVarObject_HEAD_INIT(NULL, 0)
 #else
@@ -4614,7 +4611,7 @@ static PyTypeObject spmatrixiter_tp = {
     0,                                        /* tp_hash */
     0,                                        /* tp_call */
     0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
+    PyObject_GenericGetAttr,                  /* tp_getattro */
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,  /* tp_flags */
@@ -4623,7 +4620,7 @@ static PyTypeObject spmatrixiter_tp = {
     0,                                        /* tp_clear */
     0,                                        /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
+    PyObject_SelfIter,                        /* tp_iter */
     (iternextfunc)spmatrixiter_next,          /* tp_iternext */
     0,                                        /* tp_methods */
 };

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,10 +18,12 @@ class TestBasic(unittest.TestCase):
     def test_basic(self):
         import cvxopt
         a = cvxopt.matrix([1.0,2.0,3.0])
+        assert list(a) == [1.0, 2.0, 3.0]
         b = cvxopt.matrix([3.0,-2.0,-1.0])
         c = cvxopt.spmatrix([1.0,-2.0,3.0],[0,2,4],[1,2,4],(6,5))
         d = cvxopt.spmatrix([1.0,2.0,5.0],[0,1,2],[0,0,0],(3,1))
-        self.assertEqualLists(list(cvxopt.mul(a,b)),[3.0,-4.0,-3.0])
+        e = cvxopt.mul(a, b)
+        self.assertEqualLists(e, [3.0,-4.0,-3.0])
         self.assertAlmostEqualLists(list(cvxopt.div(a,b)),[1.0/3.0,-1.0,-3.0])
         self.assertAlmostEqual(cvxopt.div([1.0,2.0,0.25]),2.0)
         self.assertEqualLists(list(cvxopt.min(a,b)),[1.0,-2.0,-1.0])


### PR DESCRIPTION
xref conda-forge/cvxopt-feedstock#45

It turns out `spmatrixiter_tp` and `matrixiter_tp` never called `PyType_Ready`. They also modified pointers to functions on new instances, which is not officially supported by the C-API. This caused segfaults when using cvxopt on PyPy.