### PR TITLE
docs: fix simple typo, heigths -> heights

### DIFF
--- a/examples/book/chap8/floorplan.py
+++ b/examples/book/chap8/floorplan.py
@@ -40,7 +40,7 @@ def floorplan(Amin):
     #
     # W, H:  scalars; bounding box width and height
     # x, y:  5-vectors; coordinates of bottom left corners of blocks
-    # w, h:  5-vectors; widths and heigths of the 5 blocks
+    # w, h:  5-vectors; widths and heights of the 5 blocks
 
     rho, gamma = 1.0, 5.0   # min spacing, min aspect ratio
 

--- a/examples/doc/chap9/floorplan.py
+++ b/examples/doc/chap9/floorplan.py
@@ -25,7 +25,7 @@ def floorplan(Amin):
     #  
     # W, H:  scalars; bounding box width and height  
     # x, y:  5-vectors; coordinates of bottom left corners of blocks  
-    # w, h:  5-vectors; widths and heigths of the 5 blocks  
+    # w, h:  5-vectors; widths and heights of the 5 blocks  
  
     rho, gamma = 1.0, 5.0   # min spacing, min aspect ratio  
  


### PR DESCRIPTION
There is a small typo in examples/book/chap8/floorplan.py, examples/doc/chap9/floorplan.py.

Should read `heights` rather than `heigths`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md