### PR TITLE
Make create_indexlist declaration match definition

### DIFF
--- a/src/C/sparse.c
+++ b/src/C/sparse.c
@@ -49,7 +49,7 @@ extern matrix * Matrix_NewFromMatrix(matrix *, int) ;
 extern matrix * Matrix_NewFromSequence(PyObject *, int) ;
 extern matrix * Matrix_NewFromPyBuffer(PyObject *, int, int *) ;
 extern matrix * Matrix_NewFromNumber(int , int , int , void *, int ) ;
-extern matrix * create_indexlist(int, PyObject *) ;
+extern matrix * create_indexlist(int_t, PyObject *) ;
 extern matrix * Matrix_New(int, int, int) ;
 extern matrix * dense(spmatrix *) ;
 extern PyObject * matrix_add(PyObject *, PyObject *) ;


### PR DESCRIPTION
The Fedora project is building all packages with Link-Time Optimization (LTO), which gives the compiler the ability to compare declarations and definitions in different compilation units.  GCC complains that the first parameter of the `create_indexlist` declaration in `sparse.c` does not match the definition in `dense.c`.  This patch makes them match.