### PR TITLE
Add missing parentheses for python 3.10 compatibility

### DIFF
--- a/src/C/base.c
+++ b/src/C/base.c
@@ -353,7 +353,7 @@ int (*mtx_rem[])(void *, number, int) = { mtx_irem, mtx_drem };
 /* val_type = 0: (sp)matrix if type = 0, PY_NUMBER if type = 1 */
 int get_id(void *val, int val_type) {
   if (!val_type) {
-    if Matrix_Check((PyObject *)val)
+    if (Matrix_Check((PyObject *)val))
     return MAT_ID((matrix *)val);
     else
       return SP_ID((spmatrix *)val);

--- a/src/C/sparse.c
+++ b/src/C/sparse.c
@@ -426,7 +426,7 @@ if (!A) return NULL;
                 SP_COL(A)[nk+1]++;
               }
             }
-          } else if SpMatrix_Check(Lij) {
+          } else if (SpMatrix_Check(Lij)) {
 
             int_t ik;
             for (ik=SP_COL(Lij)[jk]; ik<SP_COL(Lij)[jk+1]; ik++) {


### PR DESCRIPTION
With python 3.10a6, the cvxopt build has started to fail, with errors such as this:
```
In file included from /usr/include/python3.10/Python.h:87,
                 from src/C/base.c:24:
src/C/base.c: In function ‘get_id’:
/usr/include/python3.10/object.h:242:38: error: expected ‘(’ before ‘_PyObject_TypeCheck’
  242 | #define PyObject_TypeCheck(ob, type) _PyObject_TypeCheck(_PyObject_CAST(ob), type)
      |                                      ^~~~~~~~~~~~~~~~~~~
src/C/cvxopt.h:73:28: note: in expansion of macro ‘PyObject_TypeCheck’
   73 | #define Matrix_Check(self) PyObject_TypeCheck(self, &matrix_tp)
      |                            ^~~~~~~~~~~~~~~~~~
src/C/base.c:356:8: note: in expansion of macro ‘Matrix_Check’
  356 |     if Matrix_Check((PyObject *)val)
      |        ^~~~~~~~~~~~
src/C/base.c:371:1: warning: control reaches end of non-void function [-Wreturn-type]
  371 | }
      | ^
error: command '/usr/bin/gcc' failed with exit code 1
```

Reminiscent of https://github.com/cvxopt/cvxopt/pull/164, the cause is an if expression that used to expand to a parenthesized expression, but no longer does.