### PR TITLE
Avoid "invalid escape sequence" when parsing the file

### DIFF
--- a/src/python/misc.py
+++ b/src/python/misc.py
@@ -963,7 +963,7 @@ if use_C:
   sinv = misc_solvers.sinv
 else:
   def sinv(x, y, dims, mnl = 0):   
-    """
+    r"""
     The inverse product x := (y o\ x), when the 's' components of y are 
     diagonal.
     """


### PR DESCRIPTION
pytest with assert rewrite parses the file with help of the `ast`
Python module. It received a SyntaxError on this line.