### PR TITLE
REL: pass `python_requires` to `setuptools.setup`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,9 @@ SUITESPARSE_LIB_DIR = os.environ.get("CVXOPT_SUITESPARSE_LIB_DIR",SUITESPARSE_LI
 SUITESPARSE_INC_DIR = os.environ.get("CVXOPT_SUITESPARSE_INC_DIR",SUITESPARSE_INC_DIR)
 SUITESPARSE_SRC_DIR = os.environ.get("CVXOPT_SUITESPARSE_SRC_DIR",SUITESPARSE_SRC_DIR)
 MSVC = int(os.environ.get("CVXOPT_MSVC",MSVC)) == True
+PYTHON_REQUIRES = (
+    '>=2.7, !=3.0.*, !=3.1.*, '
+    '!=3.2.*, !=3.3.*, !=3.4.*')
 INSTALL_REQUIRES = os.environ.get("CVXOPT_INSTALL_REQUIRES",[])
 if type(INSTALL_REQUIRES) is str: INSTALL_REQUIRES = INSTALL_REQUIRES.strip().split(';')
 
@@ -274,6 +277,7 @@ language.''',
     ext_modules = extmods,
     package_dir = {"cvxopt": "src/python"},
     packages = ["cvxopt"],
+    python_requires=PYTHON_REQUIRES,
     install_requires = INSTALL_REQUIRES,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
These changes:

- pass the parameter `python_requires` to the function `setuptools.setup` when called from the module `setup.py`. Doing so [ensures](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires) that `cvxopt` will not be downloaded from PyPI by `pip` for installation on unsupported Python versions ([relevant](https://python3statement.org/practicalities/)). The choice of Python versions to list in `python_requires` is discussed in a section below.

  Requiring Python >= 3.7 would be a separate commit, and seems orthogonal to the changes in this pull request. The use of the parameter `python_requires` also prepares for when Python >= 3.\* will be required.

- use an underscore in `description_file`, as required by `setuptools`. Dashes are deprecated and will be unsupported by `setuptools` in the future. Before these changes, `setuptools` emits the warning:

  ```
  UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  ```


## Which Python versions `cvxopt` supports

On PyPI I read that for [`cvxopt == 1.2.6`](https://pypi.org/project/cvxopt/1.2.6/#files) wheels are available for CPython 2.7, 3.5, 3.6, 3.7, 3.8, 3.9. This is in accord with `cvxopt` documentation: <http://cvxopt.org/install/index.html#installing-a-pre-built-package>.

In the file `setup.py`, the Trove classifiers mention only Python 3:

https://github.com/cvxopt/cvxopt/blob/02e6df7800f5cb56fd7be161c69d71d919b54051/setup.py#L284-L285

On GitHub Actions, the tested Python versions are:

https://github.com/cvxopt/cvxopt/blob/02e6df7800f5cb56fd7be161c69d71d919b54051/.github/workflows/linux_build.yml#L21

https://github.com/cvxopt/cvxopt/blob/02e6df7800f5cb56fd7be161c69d71d919b54051/.github/workflows/macos_build.yml#L28

https://github.com/cvxopt/cvxopt/blob/02e6df7800f5cb56fd7be161c69d71d919b54051/.github/workflows/windows_build.yml#L25

[Python 2.7 is unsupported](https://www.python.org/dev/peps/pep-0373/), and [Python 3.6 will be so](https://www.python.org/dev/peps/pep-0494/) in 3 months:
<https://devguide.python.org/#status-of-python-branches>

So it seems that requiring Python 3.7 may be relevant at this time. In any case, the change of Python version required by `cvxopt` is orthogonal to this pull request. I defined `python_requires` based on what wheels are available for `cvxopt == 1.2.6` on PyPI.