### PR TITLE
Remove Python 2.7 supports (refer #212)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -28,21 +28,21 @@ using `pip <https://pip.pypa.io>`_::
 
 Wheels for Linux:
 
-* are available for Python 2.7, 3.3, 3.4, 3.5, and 3.6 (32 and 64 bit)
+* are available for Python 3.3, 3.4, 3.5, and 3.6 (32 and 64 bit)
 * are linked against OpenBLAS
 * include all optional extensions (DSDP, GLPK, GSL, and FFTW)
 
 Wheels for macOS:
 
-* are available for Python 2.7, 3.4, 3.5, and 3.6 (universal binaries)
+* are available for Python 3.4, 3.5, and 3.6 (universal binaries)
 * are linked against OpenBLAS
 * include all optional extensions (DSDP, GLPK, GSL, and FFTW)
 
 Wheels for Windows:
 
-* are available for Python 2.7, 3.4, 3.5, and 3.6 (64 bit only)
+* are available for Python 3.4, 3.5, and 3.6 (64 bit only)
 * are linked against MKL
-* Python 3.5+ wheels include the optional extension GLPK (wheels for Python 2.7 and 3.4 include none of the optional extensions)
+* Python 3.5+ wheels include the optional extension GLPK (wheels for Python 3.4 include none of the optional extensions)
 
 
 Building and installing from source
@@ -51,7 +51,7 @@ Building and installing from source
 Required and optional software
 ------------------------------
 
-The package requires version 2.7 or 3.x of Python, and building from
+The package requires version 3.x of Python, and building from
 source requires core binaries and header files and libraries for Python.
 
 The installation requires BLAS and LAPACK. Using an architecture

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ SUITESPARSE_INC_DIR = os.environ.get("CVXOPT_SUITESPARSE_INC_DIR",SUITESPARSE_IN
 SUITESPARSE_SRC_DIR = os.environ.get("CVXOPT_SUITESPARSE_SRC_DIR",SUITESPARSE_SRC_DIR)
 MSVC = int(os.environ.get("CVXOPT_MSVC",MSVC)) == True
 PYTHON_REQUIRES = (
-    '>=2.7, !=3.0.*, !=3.1.*, '
+    '!=3.0.*, !=3.1.*, '
     '!=3.2.*, !=3.3.*, !=3.4.*')
 INSTALL_REQUIRES = os.environ.get("CVXOPT_INSTALL_REQUIRES",[])
 if type(INSTALL_REQUIRES) is str: INSTALL_REQUIRES = INSTALL_REQUIRES.strip().split(';')


### PR DESCRIPTION
Hi all. 
It would be good to remove description for Python 2.7 support, since Python 2.7 is no more supported (refer #212).