### PR TITLE
Replace _PyUnicode_AsString with PyUnicode_AsUTF8

### DIFF
--- a/src/C/amd.c
+++ b/src/C/amd.c
@@ -90,10 +90,10 @@ static int set_defaults(double *control)
     while (PyDict_Next(param, &pos, &key, &value))
 #if PY_MAJOR_VERSION >= 3
         if ((PyUnicode_Check(key)) && 
-            get_param_idx(_PyUnicode_AsString(key),&param_id)) {
+            get_param_idx(PyUnicode_AsUTF8(key),&param_id)) {
             if (!PyLong_Check(value) && !PyFloat_Check(value)){
                 sprintf(err_str, "invalid value for AMD parameter: %-.20s",
-                    _PyUnicode_AsString(key));
+                    PyUnicode_AsUTF8(key));
 #else
         if ((keystr = PyString_AsString(key)) && get_param_idx(keystr,
             &param_id)) {

--- a/src/C/cholmod.c
+++ b/src/C/cholmod.c
@@ -105,7 +105,7 @@ static int set_options(void)
     while (PyDict_Next(param, &pos, &key, &value))
 #if PY_MAJOR_VERSION >= 3
         if (PyUnicode_Check(key)) {
-            const char *keystr = _PyUnicode_AsString(key);
+            const char *keystr = PyUnicode_AsUTF8(key);
             if (!strcmp("supernodal", keystr) && PyLong_Check(value))
                 Common.supernodal = (int) PyLong_AsLong(value);
             else if (!strcmp("print", keystr) && PyLong_Check(value))

--- a/src/C/dsdp.c
+++ b/src/C/dsdp.c
@@ -189,7 +189,7 @@ static PyObject* solvesdp(PyObject *self, PyObject *args,
     while (PyDict_Next(param, &pos, &key, &value))
 #if PY_MAJOR_VERSION >= 3
 	if (PyUnicode_Check(key)) {
-	    keystr = _PyUnicode_AsString(key);
+	    keystr = PyUnicode_AsUTF8(key);
 #else
         if ((keystr = PyString_AsString(key))){
 #endif


### PR DESCRIPTION
The Fedora Linux distribution has begun doing test builds with the current alpha version of python 3.13, to find problems well before the release of 3.13.  The cvxopt package failed to build because the `_PyUnicode_AsString` macro has been removed.  Since python 3.3, it has been a macro that simply expands to `PyUnicode_AsUTF8`, so replace the macro with its expansion.  If I am reading setup.py correctly, you already require python 3.5 or greater anyway, so the replacement should not cause any issues.