### PR TITLE
Fix out-of-bounds access when `view->ndim == 2`

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout source    
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -16,6 +16,8 @@ jobs:
       SUITESPARSE_SHA256: 59c6ca2959623f0c69226cf9afb9a018d12a37fab3a8869db5f6d7f83b6b147d
       DSDP_VERSION: 5.8
       DSDP_SHA256: 26aa624525a636de272c0b329e2dfd01a0d5b7827f1c1c76f393d71e37dead70
+      CVXOPT_SUITESPARSE_LIB_DIR: /usr/local/lib
+      CVXOPT_SUITESPARSE_INC_DIR: /usr/local/include/suitesparse
       CVXOPT_DSDP_LIB_DIR: /usr/local/lib
       CVXOPT_DSDP_INC_DIR: /usr/local/include
       CVXOPT_BLAS_LIB_DIR: /usr/local/opt/openblas/lib
@@ -34,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout source    
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -45,6 +47,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        brew --prefix
         brew install openblas suite-sparse glpk gsl fftw
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools setuptools_scm build wheel pytest pytest-cov coveralls 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/src/C/dense.c
+++ b/src/C/dense.c
@@ -253,25 +253,27 @@ matrix *Matrix_NewFromPyBuffer(PyObject *obj, int id, int *ndim)
    for (i=0; i< (int)view->shape[0]; i++, cnt++) {
      
      number n;
+     const Py_ssize_t stride0 = view->strides[0];
+     const Py_ssize_t stride1 = view->ndim == 2 ? view->strides[1] : 0;
      switch (id) {
      case INT :
        if (int_to_int_t)
 	 MAT_BUFI(a)[cnt] =
-	   *(int *)((unsigned char*)view->buf+i*view->strides[0]+j*view->strides[1]);
+	   *(int *)((unsigned char*)view->buf+i*stride0+j*stride1);
        else
 	 MAT_BUFI(a)[cnt] =
-	   *(int_t *)((unsigned char*)view->buf+i*view->strides[0]+j*view->strides[1]);
+	   *(int_t *)((unsigned char*)view->buf+i*stride0+j*stride1);
        break;
      case DOUBLE:
        switch (src_id) {
        case INT:
 	 if (int_to_int_t)
-	   n.d = *(int *)((unsigned char*)view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.d = *(int *)((unsigned char*)view->buf + i*stride0+j*stride1);
 	 else
-	   n.d = *(int_t *)((unsigned char*)view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.d = *(int_t *)((unsigned char*)view->buf + i*stride0+j*stride1);
 	 break;
        case DOUBLE:
-	 n.d = *(double *)((unsigned char*)view->buf + i*view->strides[0]+j*view->strides[1]);
+	 n.d = *(double *)((unsigned char*)view->buf + i*stride0+j*stride1);
 	 break;
        }
        MAT_BUFD(a)[cnt] = n.d;
@@ -281,28 +283,28 @@ matrix *Matrix_NewFromPyBuffer(PyObject *obj, int id, int *ndim)
        case INT:
 #ifndef _MSC_VER
 	 if (int_to_int_t)
-	   n.z = *(int *)((unsigned char*)view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.z = *(int *)((unsigned char*)view->buf + i*stride0+j*stride1);
 	 else
-	   n.z = *(int_t *)((unsigned char*)view->buf + i*view->strides[0]+j*view->strides[1]);
+	   n.z = *(int_t *)((unsigned char*)view->buf + i*stride0+j*stride1);
 #else
 	 if (int_to_int_t)
-	   n.z = _Cbuild((double) *(int *)((unsigned char*)view->buf + i*view->strides[0]+j*view->strides[1]),0.0);
+	   n.z = _Cbuild((double) *(int *)((unsigned char*)view->buf + i*stride0+j*stride1),0.0);
 	 else
-	   n.z = _Cbuild((double) *(int_t *)((unsigned char*)view->buf + i*view->strides[0]+j*view->strides[1]),0.0);
+	   n.z = _Cbuild((double) *(int_t *)((unsigned char*)view->buf + i*stride0+j*stride1),0.0);
 #endif
     	 break;
        case DOUBLE:
 #ifndef _MSC_VER
-	 n.z = *(double *)((unsigned char*)view->buf+i*view->strides[0]+j*view->strides[1]);
+	 n.z = *(double *)((unsigned char*)view->buf+i*stride0+j*stride1);
 #else
-	 n.z = _Cbuild(*(double *)((unsigned char*)view->buf+i*view->strides[0]+j*view->strides[1]),0.0);
+	 n.z = _Cbuild(*(double *)((unsigned char*)view->buf+i*stride0+j*stride1),0.0);
 #endif
 	 break;
        case COMPLEX:
 #ifndef _MSC_VER
-	 n.z = *(double complex *)((unsigned char*)view->buf+i*view->strides[0]+j*view->strides[1]);
+	 n.z = *(double complex *)((unsigned char*)view->buf+i*stride0+j*stride1);
 #else
-	 n.z = *(_Dcomplex *)((unsigned char*)view->buf+i*view->strides[0]+j*view->strides[1]);
+	 n.z = *(_Dcomplex *)((unsigned char*)view->buf+i*stride0+j*stride1);
 #endif
 	 break;
        }


### PR DESCRIPTION
The current code might assume that the dynamic allocation of `view->strides` is followed by zero padding, but this is still an erroneous access. This change was originally proposed by Thomas Köppe.