### PR TITLE
fix: fix SUITESPARSE_INC_DIR guess on Arch Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,10 @@ else:
         # CentOS/Fedora/RedHat
         SUITESPARSE_LIB_DIR = "/usr/lib64"
         SUITESPARSE_INC_DIR = "/usr/include/suitesparse"
+    elif glob("/usr/lib/libsuitesparse*"):
+        # Arch Linux
+        SUITESPARSE_LIB_DIR = "/usr/lib"
+        SUITESPARSE_INC_DIR = "/usr/include/suitesparse"
     else:
         # Default
         SUITESPARSE_LIB_DIR = '/usr/lib'


### PR DESCRIPTION
On the Arch Linux x86_64 side, `/usr/lib64` is a symlink to `/lib`, while this is not the case in other ports (riscv, aarch64 etc)