### PR TITLE
Towards release via PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: "Bump version and create release"
+description: "Bumps version, creates a tag, and publishes a release."
+
+inputs:
+  github_token:
+    description: "GitHub token for authentication"
+    required: true
+
+outputs:
+  new_tag:
+    description: "New tag"
+    value: ${{ steps.tag_version.outputs.new_tag }}
+
+runs:
+  using: "composite"
+
+  steps:
+    # -----------------------------------------------------------------------------
+    # Step 1: Bump version and tag
+    # -----------------------------------------------------------------------------
+    - name: Bump version and tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.2
+      with:
+        github_token: ${{ inputs.github_token }}
+
+    # -----------------------------------------------------------------------------
+    # Step 2: Create GitHub release
+    # -----------------------------------------------------------------------------
+    - name: Create GitHub release without artifacts
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.tag_version.outputs.new_tag }}
+        generate_release_notes: true
+
+    - name: Debug Output Tag
+      shell: bash
+      run: |
+          echo "DEBUG: ${{ steps.tag_version.outputs.new_tag }}"
+          echo "new_tag=${{ steps.tag_version.outputs.new_tag }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,35 @@ jobs:
       # write some files into a dist folder
       - name: Write
         run: |
-          mkdir -p dist/linux
+          mkdir -p dist
           echo "Tag: ${{ needs.tagging.outputs.new_tag }}" 
-          echo "Tag: ${{ needs.tagging.outputs.new_tag }}" > dist/linux/maffay.txt
+          echo "Tag: ${{ needs.tagging.outputs.new_tag }}" > dist/maffay.txt
           ls -R dist
-          # publish more sophisticated stuff, e.g. wheels etc.
+          # todo: build wheels etc.
 
       - name: Create GitHub release with artifacts
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.tagging.outputs.new_tag }}
           generate_release_notes: true
-          files: dist/linux/*
+          files: dist/*
 
+  # this will be publication to PyPI
+  #publish:
+  #  needs: tag
+  #  runs-on: ubuntu-latest
+  #  environment: release
+
+  #  permissions:
+  #    contents: read
+  #    # This permission is required for trusted publishing.
+  #    id-token: write
+
+  #  steps:
+  #    - name: Checkout [${{ github.repository }}]
+  #      uses: actions/checkout@v4
+
+  #    - uses: actions/download-artifact@v4
+  #      with:
+  #        name: dist
+  #        path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: tagging
     steps:
-      - name: build
-        uses: tschm/cradle/actions/build@v0.1.56
+      # write some files into a dist folder
+      - name: Write
+        run: |
+          mkdir -p dist
+          touch dist/maffay.txt
+
+      - name: Create GitHub release with artifacts
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ needs.tagging.outputs.new_tag }}
+          tag_name: ${{ needs.tagging.output.new_tag }}
+          generate_release_notes: true
+          files: dist/*
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,30 @@
-name: "Bump version and create release"
-description: "Bumps version, creates a tag, and publishes a release."
+name: Bump version and publish
 
-inputs:
-  github_token:
-    description: "GitHub token for authentication"
-    required: true
+on:
+  workflow_dispatch:
 
-outputs:
-  new_tag:
-    description: "New tag"
-    value: ${{ steps.tag_version.outputs.new_tag }}
+jobs:
+  tag:
+    permissions:
+      contents: write
 
-runs:
-  using: "composite"
+    runs-on: ubuntu-latest
 
-  steps:
-    # -----------------------------------------------------------------------------
-    # Step 1: Bump version and tag
-    # -----------------------------------------------------------------------------
-    - name: Bump version and tag
-      id: tag_version
-      uses: mathieudutour/github-tag-action@v6.2
-      with:
-        github_token: ${{ inputs.github_token }}
+    steps:
+      - name: Bump version and tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-    # -----------------------------------------------------------------------------
-    # Step 2: Create GitHub release
-    # -----------------------------------------------------------------------------
-    - name: Create GitHub release without artifacts
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ steps.tag_version.outputs.new_tag }}
-        generate_release_notes: true
 
-    - name: Debug Output Tag
-      shell: bash
-      run: |
+      - name: Create GitHub release without artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          generate_release_notes: true
+
+      - name: Debug Output Tag
+        run: |
           echo "DEBUG: ${{ steps.tag_version.outputs.new_tag }}"
           echo "new_tag=${{ steps.tag_version.outputs.new_tag }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Write
         run: |
           mkdir -p dist
+          echo "Tag: ${{ needs.tagging.output.new_tag }}" 
           touch dist/maffay.txt
 
       - name: Create GitHub release with artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Write
         run: |
           mkdir -p dist
-          echo "Tag: ${{ needs.tagging.output.new_tag }}" 
+          echo "Tag: ${{ needs.tagging.outputs.new_tag }}" 
           touch dist/maffay.txt
 
       - name: Create GitHub release with artifacts
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.tagging.output.new_tag }}
+          tag_name: ${{ needs.tagging.outputs.new_tag }}
           generate_release_notes: true
           files: dist/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,10 @@ jobs:
       # write some files into a dist folder
       - name: Write
         run: |
-          mkdir -p dist
+          mkdir -p dist/linux
           echo "Tag: ${{ needs.tagging.outputs.new_tag }}" 
-          touch dist/maffay.txt
+          echo "Tag: ${{ needs.tagging.outputs.new_tag }}" > dist/linux/maffay.txt
+          # publish more sophisticated stuff, e.g. wheels etc.
 
       - name: Create GitHub release with artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,28 +3,27 @@ name: Bump version and publish
 on:
   workflow_dispatch:
 
-jobs:
-  tag:
-    permissions:
-      contents: write
+permissions:
+  contents: write
 
+jobs:
+  tagging:
     runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag_step.outputs.new_tag }}
 
     steps:
-      - name: Bump version and tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+      - name: Generate Tag
+        id: tag_step
+        uses: tschm/cradle/actions/tag@v0.1.56
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-
-      - name: Create GitHub release without artifacts
-        uses: softprops/action-gh-release@v2
+  build:
+    runs-on: ubuntu-latest
+    needs: tagging
+    steps:
+      - name: build
+        uses: tschm/cradle/actions/build@v0.1.56
         with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          generate_release_notes: true
-
-      - name: Debug Output Tag
-        run: |
-          echo "DEBUG: ${{ steps.tag_version.outputs.new_tag }}"
-          echo "new_tag=${{ steps.tag_version.outputs.new_tag }}" >> "$GITHUB_OUTPUT"
+          tag: ${{ needs.tagging.outputs.new_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           mkdir -p dist/linux
           echo "Tag: ${{ needs.tagging.outputs.new_tag }}" 
           echo "Tag: ${{ needs.tagging.outputs.new_tag }}" > dist/linux/maffay.txt
+          ls -R dist
           # publish more sophisticated stuff, e.g. wheels etc.
 
       - name: Create GitHub release with artifacts
@@ -36,5 +37,5 @@ jobs:
         with:
           tag_name: ${{ needs.tagging.outputs.new_tag }}
           generate_release_notes: true
-          files: dist/*
+          files: dist/linux/*
 


### PR DESCRIPTION
I have added a release.yml.

The jobs in there can only be triggered manually (via Actions...). You can specify there the build of the wheels etc and store them all in a dist folder which will be part of the release on GitHub. This folder is then shared with PyPI (PyPI has changed to trusted publishing. I can help you to setup the channels on PyPI)